### PR TITLE
Release/1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # react-use-rect
 
-This hook makes it easy to measure a DOM element boundaries (DOMRect).
+The hook that measures a DOM element boundaries (DOMRect).
 
-It's especially useful when it's needed to re-measure boundaries when element size changes, window resizes, parent element scrolls or transition ends as well.
+It responds to a target element and window size changes, parent elements scroll changes and transition ends as well.
 
 ## Installation
 
@@ -17,14 +17,12 @@ import React from 'react';
 import { useRect } from 'react-use-rect';
 
 function Component() {
-  const [rect, ref] = useRect();
+  const [ref, rect] = useRect();
   return <div ref={ref} />;
 }
 ```
 
 ## Options
-
-The hook accepts an object of options.
 
 ```typescript
 useRect({ scroll: true, transitionEnd: true });
@@ -34,10 +32,12 @@ useRect({ scroll: true, transitionEnd: true });
 
 _default: false_
 
-If enabled, element boundaries will be re-measured when the scroll took place.
+If enabled, it will respond to scroll changes.
+
+_NOTE: Please, use this option only if you're sure you intend to update an element boundaries on scroll changes. Ubiquitous usage of this option can have a negative impact on scroll performance._
 
 ### transitionEnd
 
 _default: false_
 
-If enabled, element boundaries will be re-measured when transition ends.
+If enabled, it will respond to transition ends.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-use-rect",
-  "version": "0.1.0-alpha.6",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-use-rect",
-  "version": "1.0.0",
+  "version": "1.1.0-alpha.1",
   "description": "Hook that measures element boundaries",
   "license": "MIT",
   "author": "Vladimir Ivanenko <d521bb85@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "src"
   ],
   "peerDependencies": {
-    "react": "^17.0.1"
+    "react": "^16.8.0 || ^17.0.0"
   },
   "dependencies": {
     "@juggle/resize-observer": "^3.2.0",

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,4 +14,4 @@ export interface Options {
   transitionEnd?: boolean;
 }
 
-export type Result = [Rect, (element: Element | null) => void];
+export type Result = [(element: Element | null) => void, Rect];

--- a/src/useRect.ts
+++ b/src/useRect.ts
@@ -28,10 +28,13 @@ export function useRect(options: Options = {}): Result {
     }
   }, [element, rect]);
 
-  useIsomorphicLayoutEffect(update);
-
   const updateRef = useRef(update);
-  updateRef.current = update;
+
+  useEffect(() => {
+    updateRef.current = update;
+  }, [update]);
+
+  useIsomorphicLayoutEffect(update);
 
   useEffect(() => {
     return listenTo('resize', () => updateRef.current());

--- a/src/useRect.ts
+++ b/src/useRect.ts
@@ -64,5 +64,5 @@ export function useRect(options: Options = {}): Result {
     return () => observer.disconnect();
   }, [element]);
 
-  return [rect, setElement];
+  return [setElement, rect];
 }

--- a/src/useRect.ts
+++ b/src/useRect.ts
@@ -35,7 +35,7 @@ export function useRect(options: Options = {}): Result {
 
   useEffect(() => {
     return listenTo('resize', () => updateRef.current());
-  });
+  }, []);
 
   useEffect(() => {
     if (!scroll) {

--- a/src/utils/doesEventTargetContainElement.ts
+++ b/src/utils/doesEventTargetContainElement.ts
@@ -1,0 +1,8 @@
+export function doesEventTargetContainElement(
+  target: EventTarget | null,
+  element: Element
+) {
+  return (
+    target === window || (target instanceof Node && target.contains(element))
+  );
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './areRectsNotEqual';
 export * from './useIsomorphicLayoutEffect';
 export * from './getElementRect';
-export * from './listenTo';
+export * from './listenToWindow';
+export * from './doesEventTargetContainElement';

--- a/src/utils/listenToWindow.ts
+++ b/src/utils/listenToWindow.ts
@@ -3,7 +3,10 @@ const LISTENER_CONFIG = {
   passive: true
 };
 
-export function listenTo(eventType: string, listener: () => void) {
+export function listenToWindow<K extends keyof WindowEventMap>(
+  eventType: K,
+  listener: (event: WindowEventMap[K]) => void
+) {
   window.addEventListener(eventType, listener, LISTENER_CONFIG);
 
   return () => {

--- a/test/fixture/app/App.js
+++ b/test/fixture/app/App.js
@@ -6,26 +6,6 @@ import { Controls } from './Controls';
 import { Subject } from './Subject';
 import { Aim } from './Aim';
 
-const RootStyle = createGlobalStyle`
-  ${normalize}
-
-  :root {
-    --color-light: #f5f5f5;
-    --color-dark: #212121;
-    --color-accent: #009688;
-    --color-minor: #757575;
-  }
-
-  * {
-    box-sizing: border-box;
-  }
-
-  body {
-    font: 400 normal 14px/1.3 -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji;
-    color: var(--color-dar);
-  }
-`;
-
 export function App() {
   const [options, setOptions] = useState({
     scroll: true,
@@ -33,7 +13,7 @@ export function App() {
     shifted: false
   });
 
-  const [rect, rectElementRef] = useRect({
+  const [rectElementRef, rect] = useRect({
     scroll: options.scroll,
     transitionEnd: options.transitionEnd
   });
@@ -54,6 +34,26 @@ export function App() {
     </Container>
   );
 }
+
+const RootStyle = createGlobalStyle`
+  ${normalize}
+
+  :root {
+    --color-light: #f5f5f5;
+    --color-dark: #212121;
+    --color-accent: #009688;
+    --color-minor: #757575;
+  }
+
+  * {
+    box-sizing: border-box;
+  }
+
+  body {
+    font: 400 normal 14px/1.3 -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji;
+    color: var(--color-dar);
+  }
+`;
 
 const Container = styled.div`
   display: flex;

--- a/test/unit/useRect.spec.tsx
+++ b/test/unit/useRect.spec.tsx
@@ -20,7 +20,7 @@ describe('useRect', () => {
     const testFn = jest.fn();
 
     function Component() {
-      const [rect, rectRef] = useRect();
+      const [rectRef, rect] = useRect();
       testFn(rect);
       return <div ref={rectRef} />;
     }
@@ -29,7 +29,7 @@ describe('useRect', () => {
     await waitFor(() => expect(testFn).toBeCalledWith(DEFAULT_RECT));
   });
 
-  it('should calc element rect', async () => {
+  it('should get element rect', async () => {
     const testFn = jest.fn();
 
     const fakeRect = {
@@ -46,7 +46,7 @@ describe('useRect', () => {
     mockRect(fakeRect);
 
     function Component() {
-      const [rect, rectRef] = useRect();
+      const [rectRef, rect] = useRect();
       testFn(rect);
       return <div ref={rectRef} />;
     }
@@ -59,7 +59,7 @@ describe('useRect', () => {
     const testFn = jest.fn();
 
     function Component() {
-      const [rect, rectRef] = useRect();
+      const [rectRef, rect] = useRect();
       testFn(rect);
       return <div ref={rectRef} />;
     }
@@ -87,7 +87,7 @@ describe('useRect', () => {
     const testFn = jest.fn();
 
     function Component() {
-      const [rect, rectRef] = useRect({ scroll: true });
+      const [rectRef, rect] = useRect({ scroll: true });
       testFn(rect);
       return <div ref={rectRef} />;
     }
@@ -115,7 +115,7 @@ describe('useRect', () => {
     const testFn = jest.fn();
 
     function Component() {
-      const [rect, rectRef] = useRect({ transitionEnd: true });
+      const [rectRef, rect] = useRect({ transitionEnd: true });
       testFn(rect);
       return <div ref={rectRef} />;
     }
@@ -158,7 +158,7 @@ describe('useRect', () => {
     const testFn = jest.fn();
 
     function Component() {
-      const [rect, rectRef] = useRect();
+      const [rectRef, rect] = useRect();
       testFn(rect);
       return <div ref={rectRef} />;
     }


### PR DESCRIPTION
Contains a minor **BREAKING CHANGE**: an order of the `useRect` return arguments has changed in order to be consistent with the vast majority hooks.