### PR TITLE
Add compatibility with React 16.8.0 and React 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prepublishOnly": "npm run test && npm run build"
   },
   "peerDependencies": {
-    "react": "^17.0.2 || ^18.0.0"
+    "react": "^16.8.0 || ^17.0.2 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
   },
   "devDependencies": {
     "@testing-library/react": "^13.1.1",


### PR DESCRIPTION
Hello! This PR adds compatibility with React 19 (currently available as a [release candidate](https://react.dev/blog/2024/04/25/react-19)) and React ^16.8.0 ([the one with hooks](https://legacy.reactjs.org/blog/2019/02/06/react-v16.8.0.html)).

This PR resolves #494. Thank you for creating `react-use-rect`!

### Testing with React 19

- [Installed React 19 rc](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#installing)
- Ran `npm install --legacy-peer-deps`  (because `@testing-library/react@13.4.0` specifies React 18 as a peer dependency)
- Ran `yarn test`
- Noted that tests pass

### Testing with React 16.8.x

`@testing-library/react@13.4.0` fails on older versions of React with "TypeError: actImplementation is not a function". Instead, I tested manually in the application where I'm utilizing `react-use-rect`. I manually tested with React 16.13.1 and React 16.8.6, and the functionality worked great in both cases.
